### PR TITLE
configure.ac: Remove guile v2.0 from GUILE_PKG list

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@
 # configure.ac
 #
 # Copyright (C) 2013-2020 Aleix Conchillo Flaque <aconchillo@gmail.com>
+# Copyright (C) 2021 Bonface Munyoki Kilyungi <me@bonfacemunyoki.com>
 #
 # This file is part of guile-redis.
 #
@@ -32,7 +33,7 @@ m4_pattern_forbid([PKG_CHECK_MODULES])
 m4_pattern_forbid([^GUILE_PKG])
 
 dnl Check for Guile 2.x.
-GUILE_PKG([3.0 2.2 2.0])
+GUILE_PKG([3.0 2.2])
 GUILE_PROGS
 GUILE_SITE_DIR
 


### PR DESCRIPTION
Hi @aconchillo! I was exploring a build failure in guile2.0-redis in GNU Guix and noticed that IIUC  some ice-9 binding were not present:

```
➜  guix git:(master) ✗ guix environment -C --ad-hoc guile@2.0.14 -- guile
The following derivation will be built:
   /gnu/store/f6pxq82f7ifzxmlaba72x0mn9rqfdf8b-profile.drv
The following profile hooks will be built:
   /gnu/store/3ghqadnzhddgcf8nljfzjrkyzvizn61m-manual-database.drv
   /gnu/store/4p7wnbk6bh9g6q1wlb48zmf09rlnwdxl-info-dir.drv
   /gnu/store/4q08ispks919baxrvp5g7wyipn1n98lc-fonts-dir.drv
   /gnu/store/f15hk17knzla3wzhmfyx61lwih1g5mjq-ca-certificate-bundle.drv
building CA certificate bundle...
building fonts directory...
building directory of Info manuals...
building database for manual pages...
building profile with 1 package...
GNU Guile 2.0.14
Copyright (C) 1995-2016 Free Software Foundation, Inc.

Guile comes with ABSOLUTELY NO WARRANTY; for details type `,show w'.
This program is free software, and you are welcome to redistribute it
under certain conditions; type `,show c' for details.

Enter `,help' for help.
scheme@(guile-user)> ,use (ice-9 textual-ports)
While executing meta-command:
ERROR: no code for module (ice-9 textual-ports)
```

The build for guile-redis 2.0.0 fails in Guile 2.0 since that version of Guile did not have some ice-9 bindings like `(ice-9 textual-ports)`.